### PR TITLE
Fixed an issue where a queue was not setting itself to running=false …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "partition-queue",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partition-queue",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A dead simple partitioned asynchronous queue with adjustable concurrency. Jobs with the same key are guaranteed to be processed in order.",
   "main": "index.js",
   "scripts": {

--- a/partition-queue.js
+++ b/partition-queue.js
@@ -81,12 +81,14 @@ class PartitionQueue extends EventEmitter {
 			} catch (error) {
 				done(error);
 			}
-		} else if (this.remaining === 0) {
-			this.emit('done');
+		} else {
 			queue.running = false;
-			if (this.startPromiseResolve) {
-				this.startPromiseResolve();
-				this.startPromiseResolve = null;
+			if (this.remaining === 0) {
+				this.emit('done');
+				if (this.startPromiseResolve) {
+					this.startPromiseResolve();
+					this.startPromiseResolve = null;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
…unless it was processing the last job. This would happen if a certain mix of instant resolve tasks were being added into multiple queues with async tasks.